### PR TITLE
Update cl_player_ids.lua

### DIFF
--- a/scripts/menu/client/cl_player_ids.lua
+++ b/scripts/menu/client/cl_player_ids.lua
@@ -98,6 +98,7 @@ local function togglePlayerIDsHandler()
         sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.alert_show', true)
     end
 
+    TriggerServerEvent('txAdmin:events:togglePlayerIds', isPlayerIDActive)
     debugPrint('Show Player IDs Status: ' .. tostring(isPlayerIDActive))
 end
 


### PR DESCRIPTION
I am running an rp-server and I'd like to know which admins are using id's currently. So the event can be called from another script and simply print it to the chat (Admins only). As currently there is no option to print used commands by admins to the chat.